### PR TITLE
0.5.2-alpha

### DIFF
--- a/src/brickmaster2/network/linux.py
+++ b/src/brickmaster2/network/linux.py
@@ -50,8 +50,8 @@ class BM2NetworkLinux(BM2Network):
         # Connect
         try:
             self._paho_client.connect(host=host, port=port)
-        except ConnectionRefusedError as e:
-            # These are the exceptions can happen. Wrap this as BM2RecoverableError.
+        except (ConnectionRefusedError, TimeoutError) as e:
+            # These are exceptions that we should be able to recover from with retries, ie: the broker is rebooting.
             raise brickmaster2.exceptions.BM2RecoverableError from e
         else:
             # Start the background thread.

--- a/src/brickmaster2/version.py
+++ b/src/brickmaster2/version.py
@@ -1,2 +1,2 @@
 """ Brickmaster2 Version """
-__version__ = "0.5.1"
+__version__ = "0.5.2-alpha"


### PR DESCRIPTION
- Make TimeoutErrors recoverable. This is to cover cases where the broker goes away but will come back, ie: restarts.