### PR TITLE
Sensor Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,164 @@
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -14,6 +14,7 @@ On non-Linux installs, the file must be "config.json" in the root of the board's
 | :white_check_mark: `controls` | list | Devices to controls. May be empty if none present (but then what's the point!?) |
 | :white_check_mark: `displays` | list | 7-segment displays. May be empty if none present. |
 | :white_check_mark: `scripts` | dict | Pre-defined scripts that can be run |
+| 'sensors' | list | List of defined sensors. Currently on the HTU31D I2C sensor is supported. |
 
 ### System Options
 
@@ -29,6 +30,7 @@ On non-Linux installs, the file must be "config.json" in the root of the board's
 | `indicators`          | dict   | None      | Defines GPIO pins for indicators lights.                                                                                                                       |
 | `mqtt` | dict | None | MQTT settings.                                                                                                                                                 |
 | `ha`                  | dict   | None      | Options for Home Assistant discovery. If excluded, will disable HA discovery.                                                                                  |
+| 'interface'   | string | 'wlan0' | On linux, which interface should be monitored for connectivity. |
 
 #### I2C
 I2C is required if using I2C displays (the only kind of supported displays) or Controls on an I2C board (AW9523).
@@ -177,3 +179,12 @@ is defined as a dict with the following definition.
 | :white_check_mark: `dir` | string | 'scripts'                             | Directory for scripts.                                                                                                |
 | `scan_dir`               | string | `False` on Circuitpython, else `True` | Should the script directory be scanned for script files? If so, any json file (*.json) will be processed as a script. |
 | `files`                  | list   | None                                  | **Required** for Circuitpython as it can't scan files. List of file names to include explicitly.                      |
+
+### Sensors
+:white_check_mark: **means required**
+
+| Name                             | Type   | Default | Description                                                                                                                                                      |
+|----------------------------------|--------|------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :white_check_mark: `name`        | string | None | Name of the sensor. This will be part of the topic name.                                                                                                         |
+| :white_check_mark: `type`        | string | None | Type of the control. Currently must be 'HTU31D', this is all that's supported.                                                                                   | 
+| :white_check_mark: `address` | string | None | Address of the sensor on the I2C bus. Note this must be on I2C bus 1, and must be written as a hex address in a string, ie: "0x40"                               |

--- a/brickmaster/__init__.py
+++ b/brickmaster/__init__.py
@@ -10,6 +10,8 @@ from . import gpio
 from . import network
 # Scripts
 from . import scripts
+# Sensors
+from . import sensors
 # # Utility methods.
 from . import util
 

--- a/brickmaster/controls/__init__.py
+++ b/brickmaster/controls/__init__.py
@@ -7,3 +7,4 @@ from .CtrlFlasher import CtrlFlasher
 from .CtrlNull import CtrlNull
 from .CtrlSingle import CtrlSingle
 
+

--- a/brickmaster/network/base.py
+++ b/brickmaster/network/base.py
@@ -84,8 +84,9 @@ class BM2Network:
         # Register to store objects.
         self._object_register = {
             'controls': {},
+            'displays': {},
             'scripts': {},
-            'displays': {}
+            'sensors': {}
         }
 
         # Default the logging level.
@@ -337,6 +338,7 @@ class BM2Network:
         :return: None
         """
 
+        # This shouldn't be true, since Sensors don't have topics to subscribe to. Revisit this later.
         try:
             obj_topics = action_object.topics
         except AttributeError:
@@ -350,6 +352,9 @@ class BM2Network:
             elif issubclass(type(action_object), brickmaster.scripts.BM2Script):
                 self._logger.debug("Registering script '{}' to topics '{}'".format(action_object.id, obj_topics))
                 self._object_register['scripts'][action_object.id] = action_object
+            elif issubclass(type(action_object), brickmaster.sensors.BaseSensor):
+                self._logger.debug("Registering sensor '{}' to topics '{}'".format(action_object.id, obj_topics))
+                self._object_register['sensors'][action_object.id] = action_object
             else:
                 self._logger.error("Cannot determine class of object '{}' (type: {}). Cannot register.".
                                    format(action_object.id, type(action_object)))

--- a/brickmaster/sensors/BaseSensor.py
+++ b/brickmaster/sensors/BaseSensor.py
@@ -1,0 +1,82 @@
+"""
+Brickmaster Base Sensor
+"""
+import adafruit_logging
+
+class BaseSensor:
+    """
+    Base Sensor object.
+    """
+    def __init__(self, sensor_id, name, core, icon="mdi:toy-brick", publish_time=15, log_level=adafruit_logging.WARNING):
+        """
+        Base Sensor initialization.
+
+        @param sensor_id: Short ID for the control. No spaces!
+        @type sensor_id: str
+        @param name: Long name for the control
+        @type name: str
+        @param core: Reference to the Brickmaster core object.
+        @type core: object
+        @param icon:
+        @type icon: str
+        @param publish_time:
+        @type publish_time: int
+        @param log_level: Logging level to use for the control. Technically an int, should be a valid adafruit_logging
+        constant.
+        @type log_level: int
+
+        """
+        # Save inputs.
+        # Set the ID.
+        self._sensor_id = sensor_id
+        # Set the Name.
+        self._sensor_name = name
+        # Save the reference back to the core.
+        self._core = core
+        self._icon = icon
+        self._publish_time = publish_time
+
+        # Initialize
+        self._topics = None
+        self._status = None
+
+        # Create a logger with the specified logger.
+        self._logger = adafruit_logging.getLogger('Brickmaster')
+        self._logger.setLevel(log_level)
+
+    @property
+    def topics(self):
+        """
+        List of topics to subscribe to for this control. To be read by the Network object.
+        """
+        return self._topics
+
+    @property
+    def status(self):
+        """
+        Current status of the control. Should return ON or OFF.
+
+        return str
+        """
+        raise NotImplemented("Status must be implemented in a control subclass.")
+
+    @property
+    def name(self):
+        """
+        Long name of the control. Can be descriptive. Used naming entities in Home Assistant discovery.
+        """
+        return self._sensor_name
+
+    @property
+    def icon(self):
+        """
+        The defined icon for the control.
+        """
+        return self._icon
+
+    @property
+    def id(self):
+        """
+        ID of the control. Used internally and to create entity IDs in Home Assistant discovery.
+        """
+        return self._sensor_id

--- a/brickmaster/sensors/SensorHTU31D.py
+++ b/brickmaster/sensors/SensorHTU31D.py
@@ -1,0 +1,78 @@
+"""
+Brickmaster Sensor - HTU31D Temperature and Humidity
+"""
+
+import adafruit_logging
+from .BaseSensor import BaseSensor
+import time
+import adafruit_htu31d
+
+class SensorHTU31D(BaseSensor):
+    """
+    Sensor for an HTU31D temperature/humidity sensor.
+    """
+    def __init__(self, ctrl_id, name, i2c_bus, address, core, unit="C", publish_time=6,
+                 icon="mdi:toy-brick", log_level=adafruit_logging.WARNING):
+        """
+        Args:
+            ctrl_id (str): ID of the sensor. Cannot have spaces.
+            name (str): Name of the sensor. Can be friendly.
+            i2c_bus (busio.I2C): I2C bus object
+            address (int): Address of the HTU31D sensor.
+            core (Brickmaster): Reference to the Brickmaster core.
+            unit (str): Temperature units to report. "F" or "C". Defaults to "C".
+            publish_time (int): How often data should be published, in seconds.
+            icon (str): Icon to use for discovery.
+            log_level (str): Log level to use. Defaults to Warning.
+
+        Returns:
+            None
+        """
+        super().__init__(ctrl_id, name, core, icon, publish_time, log_level)
+
+        self._i2c_bus = i2c_bus
+        self._address = address
+        if unit not in ("F", "C"):
+            raise ValueError("Unit must be 'C' for Celsis or 'F' for Farenheight")
+        self._unit = unit
+        self._latest_update = 0
+        self._latest_data = None
+        self._sensor = adafruit_htu31d.HTU31D(self._i2c_bus, self._address)
+
+    @property
+    def status(self):
+        """
+        Get status from the sensor and package it.
+
+        Args:
+            None
+
+        Returns:
+            dict
+        """
+
+        # Update every 6 seconds - 10 times a minute.
+        if time.monotonic() - self._latest_update > 6:
+            temp, humidity = self._sensor.measurements
+            # Convert temp if needed
+            if self._unit == "F":
+                temp = (temp - 32) * 5/9
+            self._latest_data = {"temperature": f"{temp:.2f}", "humidity": f"{humidity:.2f}"}
+            self._latest_update = time.monotonic()
+        return self._latest_data
+
+    def callback(self, client, topic, message):
+        """
+        Sensor callback. Does nothing.
+        """
+        pass
+
+    @property
+    def uom(self):
+        """
+        Unit of Measurement for Home Assistant. This only applies to temperature.
+        """
+        if self._unit == 'F':
+            return "°F"
+        else:
+            return "°C"

--- a/brickmaster/sensors/__init__.py
+++ b/brickmaster/sensors/__init__.py
@@ -1,0 +1,6 @@
+"""
+Brickmaster Sensors
+"""
+
+from .BaseSensor import BaseSensor
+from .SensorHTU31D import SensorHTU31D

--- a/brickmaster/version.py
+++ b/brickmaster/version.py
@@ -1,2 +1,2 @@
 """ Brickmaster2 Version """
-__version__ = "0.6.2-alpha2"
+__version__ = "0.6.2-alpha3"

--- a/hwconfigs/3dpenvsense.json
+++ b/hwconfigs/3dpenvsense.json
@@ -1,0 +1,35 @@
+
+{
+  "system": {
+    "id": "3dpenvsense",
+    "name": "3d Printer Environment Sensors",
+    "log_level": "warning",
+    "i2c": "True",
+    "ha":{
+      "area": "### Area name here. Not required, but recommended. ###"
+    },
+    "mqtt": {
+      "broker": "### Broker Hostname or IP ###",
+      "user": "### MQTT Username ###",
+      "key": "### MQTT Password ###"
+    },
+    "interface": "eth0"
+  },
+  "controls": [],
+  "displays":[],
+  "scripts": {
+    "scan_dir": "false"
+  },
+  "sensors": {
+    "ambient": {
+      "name": "Ambient",
+      "type": "HTU31D",
+      "address": "0x40"
+    },
+    "enclosure": {
+      "name": "Enclosure",
+      "type": "HTU31D",
+      "address": "0x41"
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,13 @@ requires-python = ">=3.11"
 dependencies = [
     "adafruit-circuitpython-logging",
     "adafruit-circuitpython-ht16k33",
+    "adafruit-circuitpython-htu31d",
     "Adafruit-Blinka",
     "netifaces2",
     "paho-mqtt",
     "psutil",
-    "pid"
+    "pid",
+    "RPi.GPIO"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Add support for sensors as a concept and the HTU31D temp/hum sensor specifically. Will publish every six seconds to the defined topic. Discovers two entities for the sensor. In theory this framework can be used for additional types of sensors. Have only tested it on Linux currently with the intent of running in parallel to Octoprint.