### PR TITLE
Optional config parameters, minor fixes

### DIFF
--- a/brickmaster/config.py
+++ b/brickmaster/config.py
@@ -35,14 +35,25 @@ class BM2Config:
     # Master validator
     def _validate(self):
         # Check for the required config sections.
-        required_keys = ['system', 'controls', 'scripts']
-        optional_keys = ['sensors']
+        required_keys = ['system', 'controls']
+        optional_keys = ['displays','scripts','sensors']
+        optional_defaults = {
+            'displays': [],
+            'scripts': {},
+            'sensors': []
+        }
         print(self._config)
         for key in required_keys:
             self._logger.debug("Checking for section '{}'".format(key))
             if key not in self._config:
                 self._logger.critical("Required configuration section '{}' not present. Cannot continue!".format(key))
                 sys.exit(1)
+        for key in optional_keys:
+            self._logger.debug("Checking for section '{}'".format(key))
+            if key not in self._config:
+                self._logger.info("Optional configuration section '{}' not present.".format(key))
+                self._config[key] = optional_defaults[key]
+
         # Change the logging level.
         self._validate_logging()
         self._logger.info("Config: Adjusting log level to '{}'".format(self._config['system']['log_level_name']))

--- a/brickmaster/display.py
+++ b/brickmaster/display.py
@@ -4,14 +4,22 @@ Brickmaster Display System
 
 import adafruit_logging as logger
 # from .segment_format import number_7s, time_7s
-from adafruit_ht16k33.segments import BigSeg7x4, Seg7x4
+
 import time
+
 class Display:
     """
     Brickmaster Display Class
     Create once per display.
     """
     def __init__(self, config, i2c_bus):
+
+        # Import the ht16k33 library when required.
+        try:
+            from adafruit_ht16k33.segments import BigSeg7x4, Seg7x4
+        except ImportError as ie:
+            raise ie
+
         # Create a logger
         self._logger = logger.getLogger('Brickmaster')
         # Save the config.

--- a/brickmaster/network/mqtt.py
+++ b/brickmaster/network/mqtt.py
@@ -10,6 +10,7 @@ import json
 import brickmaster.util
 import board
 import brickmaster.controls.CtrlFlasher
+import os
 
 logger = adafruit_logging.getLogger('Brickmaster')
 logger.setLevel(adafruit_logging.DEBUG)
@@ -115,11 +116,11 @@ def ha_device_info(system_id, long_name, version, ha_area=None, ip=None):
         suggested_area=ha_area,
         sw_version=str(version)
     )
-    print("MQTT: IP is '{}'".format(ip))
-    if ip is not None:
+    # print("MQTT: IP is '{}'".format(ip))
+    if ip is not None and os.uname().sysname == 'ESP32':
         # Send the configuration URL if an IP is provided. This is just a string, so could technically be a hostname.
         # Intended only for CircuitPython boards.
-        print("Got ip {} ({})".format(ip, type(ip)))
+        # print("Got ip {} ({})".format(ip, type(ip)))
         return_data['configuration_url'] = "http://" + ip + "/"
     # Only add suggested_area if it's set to not None, otherwise discovery will reject this.
     if ha_area is not None:

--- a/brickmaster/network/mqtt.py
+++ b/brickmaster/network/mqtt.py
@@ -1,5 +1,5 @@
 """
-Brickmaster2 MQTT Method Generation methods.
+Brickmaster MQTT Method Generation methods.
 
 These methods are meant to work with either the Linux or CircuitPython classes. It's the responsibility of those
 classes to handle the actual publication!

--- a/brickmaster/sensors/SensorHTU31D.py
+++ b/brickmaster/sensors/SensorHTU31D.py
@@ -5,7 +5,7 @@ Brickmaster Sensor - HTU31D Temperature and Humidity
 import adafruit_logging
 from .BaseSensor import BaseSensor
 import time
-import adafruit_htu31d
+
 
 class SensorHTU31D(BaseSensor):
     """
@@ -29,6 +29,11 @@ class SensorHTU31D(BaseSensor):
             None
         """
         super().__init__(ctrl_id, name, core, icon, publish_time, log_level)
+
+        try:
+            import adafruit_htu31d
+        except ImportError as ie:
+            raise ie
 
         self._i2c_bus = i2c_bus
         self._address = address


### PR DESCRIPTION
Key update here is making the display, sensors and scripts items in the config file optional.
If the system doesn't find these, it will quietly insert empty lists for them. This makes it easier to update from older config files that may not include these keys.